### PR TITLE
ci: change write permission for wiki.yml to "write"

### DIFF
--- a/.github/workflows/wiki.yaml
+++ b/.github/workflows/wiki.yaml
@@ -5,7 +5,7 @@ jobs:
   wiki:
     name: Update Wiki submodule
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
fixes the "401 Unauthorized" error when pushing wiki submodule update

For the record, is is [the first time](https://github.com/8VIM/8VIM/actions/workflows/wiki.yaml) the workflow is being run since it was written.

Triggered by: https://github.com/8VIM/8VIM/wiki/Home/_compare/d057ca44d46e9ef5d0971567847f5fe0634f511f...016b5e1bb6df4300fbd624469b3cb4a075d4d13e.

To-do after merge: Change the url to https://www.youtube.com/watch?v=q3OuCR0EpGo