### PR TITLE
Extend the layout for Dutch to cover the language

### DIFF
--- a/8vim/src/main/res/raw/nl.yaml
+++ b/8vim/src/main/res/raw/nl.yaml
@@ -59,12 +59,79 @@ layers:
   extra_layers:
     first:
       sectors:
+        right:
+          parts:
+            top:
+              - lower_case: "ä"
         left:
           parts:
             bottom:
-              - lower_case: ĳ
+              - lower_case: "ï"
+            top:
+              - null
+              - lower_case: "€"
+                upper_case: "¢"
         bottom:
           parts:
             left:
-              - lower_case: €
-                upper_case: ¢
+              - lower_case: "ë"
+            right:
+              - lower_case: "ö"
+              - lower_case: "ü"
+    second:
+      sectors:
+        right:
+          parts:
+            top:
+              - lower_case: "á"
+        left:
+          parts:
+            bottom:
+              - lower_case: "í"
+              - null
+              - lower_case: "ȷ́"
+                upper_case: "J́"
+            top:
+              - null
+              - lower_case: "ç"
+        bottom:
+          parts:
+            left:
+              - lower_case: "é"
+            right:
+              - lower_case: "ó"
+              - lower_case: "ú"
+    third:
+      sectors:
+        right:
+          parts:
+            top:
+              - lower_case: "à"
+        left:
+          parts:
+            bottom:
+              - lower_case: "ì"
+        bottom:
+          parts:
+            left:
+              - lower_case: "è"
+            right:
+              - lower_case: "ò"
+              - lower_case: "ù"
+    fourth:
+      sectors:
+        right:
+          parts:
+            top:
+              - lower_case: "â"
+        left:
+          parts:
+            bottom:
+              - lower_case: "î"
+        bottom:
+          parts:
+            left:
+              - lower_case: "ê"
+            right:
+              - lower_case: "ô"
+              - lower_case: "û"


### PR DESCRIPTION
The layout for Dutch did not cover the letters needed to spell the Dutch language. At minimum, to spell the words of the language, the vowels a, e, i, o and u each require versions with a ‘trema’ diaeresis to break up digraphs, and at least the e requires an acute accent for disambiguation.

Standard Dutch spelling also includes acute accents on the other vowels to express emphasis. This includes the ij digraph, which is invariably written as two separate letters; the codepoint **U+0133 LATIN SMALL LIGATURE IJ** is not used in modern Dutch. Encoding the accented j requires combining a dotless j with a combining acute accent, as Unicode has no composed, single-codepoint ‘j with acute’. In uppercase, this turns into a regular capital J with a combining acute, as the capital J is already dotless.

Pre-1995 standard spelling also used grave accents for emphasis on short vowels, which some people may still prefer. Additionally, the cedilla and e, u, i and o with circumflex are used in some loanwords.